### PR TITLE
Remove duplicate restart

### DIFF
--- a/generate_docker-compose_aio.sh
+++ b/generate_docker-compose_aio.sh
@@ -172,7 +172,6 @@ services:
       WEATHERFLOW_COLLECTOR_INFLUXDB_URL: http://wxfdashboardsaio_influxdb:8086/write?db=weatherflow
       WEATHERFLOW_COLLECTOR_INFLUXDB_USERNAME: weatherflow
       WEATHERFLOW_COLLECTOR_TOKEN: ${token}
-    restart: always
     depends_on:
       - \"wxfdashboardsaio_influxdb\"
     image: lux4rd0/weatherflow-collector:latest


### PR DESCRIPTION
There is a duplicate restart: always in the wxfdashboardsaio-collector section that prevents docker-compose up -d from starting.